### PR TITLE
Add fixture to clear tasks before and after each test

### DIFF
--- a/test/test_app.py
+++ b/test/test_app.py
@@ -7,6 +7,12 @@ def client():
     with app.test_client() as client:
         yield client
 
+@pytest.fixture(autouse=True)
+def clear_tasks():
+    tasks.clear()  # Clear tasks before each test
+    yield
+    tasks.clear()  # Clear tasks after each test
+
 def test_index_get(client):
     """Test the index route with GET method."""
     response = client.get('/')


### PR DESCRIPTION
This pull request includes a change to the `test/test_app.py` file to improve test reliability by ensuring the `tasks` list is cleared before and after each test.

* [`test/test_app.py`](diffhunk://#diff-068b5ee4c68062d8f0abb06310c2e083a3c0c01d72760cf2833a0b4c74e39548R10-R15): Added a new pytest fixture `clear_tasks` to clear the `tasks` list before and after each test to ensure tests do not interfere with each other.